### PR TITLE
Fix warnings for Elixir 1.8

### DIFF
--- a/lib/esx/model/base.ex
+++ b/lib/esx/model/base.ex
@@ -229,7 +229,7 @@ defmodule ESx.Model.Base do
 
         results =
           stream(schema, Keyword.merge(opts, chunk_size: chunk_size))
-          |> Stream.chunk(chunk_size, chunk_size, [])
+          |> Stream.chunk_every(chunk_size, chunk_size, [])
           |> Stream.map(fn chunk ->
             body = Enum.map(chunk, &transform(&1, opts))
 

--- a/lib/esx/model/response.ex
+++ b/lib/esx/model/response.ex
@@ -66,5 +66,14 @@ defmodule ESx.Model.Response do
     def reduce(%ESx.Model.Response{hits: hits}, acc, fun) do
       Enumerable.reduce(hits, acc, fun)
     end
+
+    def slice(%ESx.Model.Response{records: records})
+        when length(records) > 0 do
+      Enumerable.slice(records)
+    end
+
+    def slice(%ESx.Model.Response{hits: hits}) do
+      Enumerable.slice(hits)
+    end
   end
 end

--- a/lib/esx/transport.ex
+++ b/lib/esx/transport.ex
@@ -117,7 +117,8 @@ defmodule ESx.Transport do
 
   def resurrect_deads do
     Connection.conns()
-    |> Enum.filter_map(& &1.dead, &Connection.resurrect!/1)
+    |> Enum.filter(& &1.dead)
+    |> Enum.map(&Connection.resurrect!/1)
   end
 
   def perform_request(%__MODULE__{} = ts) do
@@ -258,7 +259,7 @@ defmodule ESx.Transport do
       {:ok, pretitfied} ->
         traceout("curl -X #{method} '#{url}' -d '#{pretitfied}'\n")
 
-      {:error, message} ->
+      {:error, _message} ->
         traceout("curl -X #{method} '#{url}' -d '#### couldn't prettify body ####'\n")
     end
   end

--- a/lib/esx/transport/sniffer.ex
+++ b/lib/esx/transport/sniffer.ex
@@ -5,7 +5,7 @@ defmodule ESx.Transport.Sniffer do
   # alias ESx.Transport.Config
 
   @protocol "http"
-  @timeout 1
+  # @timeout 1
 
   def urls(%{} = ts) do
     Transport.perform_request(ts, "GET", "_nodes/http", %{}, nil)

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,10 @@ defmodule ESx.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison], mod: {ESx, []}]
+    [
+      extra_applications: [:logger],
+      mod: {ESx, []}
+    ]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
There was one more I wasn't able to fix:
```
Compiling 73 files (.ex)
warning: this check/guard will always yield the same result
  lib/my_app/images/image.ex:1
```
I'm not sure which module this is coming from, even after spending a lot of time trying to find it.